### PR TITLE
Update python versions tested on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: python
 python:
   - "2.7"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
   - "3.6"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors


### PR DESCRIPTION
Hello :wave:,
I think we should drop support of old python runtimes and keep only Python 3.6/3.7/3.8 versions to make build works again on Travis (+ Python 2.7 :trollface:)

This seems reasonable to me :)
